### PR TITLE
Update verilated.cpp

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -33,6 +33,7 @@
 #include <sys/stat.h>  // mkdir
 #include <list>
 #include <utility>
+#include <limits>
 
 // clang-format off
 #if defined(_WIN32) || defined(__MINGW32__)


### PR DESCRIPTION
To fix the sequence of error in GCC-11+
> error: ‘numeric_limits’ is not a member of ‘std’
> error: ‘::max’ has not been declared; did you mean ‘std::max’?

Add cpp header \<limits\> to verilated.cpp